### PR TITLE
vmegarover_controller.yamlでの車輪軸間距離の修正

### DIFF
--- a/configuration_files/vmegarover_controller.yaml
+++ b/configuration_files/vmegarover_controller.yaml
@@ -13,7 +13,7 @@ vmegarover:
     twist_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
 
     # 車輪の半径と両輪の軸間距離
-    wheel_separation : 0.313982
+    wheel_separation : 0.28398
     wheel_radius : 0.076
 
     wheel_separation_multiplier: 1.0 # default: 1.0


### PR DESCRIPTION
vmegarover_controller.yaml記載の車輪軸間距離の設定が間違っていたため [ 2db048494cd2bad819ea153845a97b690668c225 ]で修正しました。

Gazebo上での車輪位置の設定はvmegarover.urdf.xacro及びvwheel.urdf.xacroで以下のようになっていますが、  
`<cylinder>`は指定点を中心として設定されるため、車輪間の距離は0.313982 = 0.14199 * 2 + 0.03(車輪幅)ではなく、 0.28398 =  0.14199 * 2 が正しいと思われます。
 
`vmegarover.urdf.xacro`

```xml
  <!-- Wheel -->
  <!-- Right Wheel -->
  <xacro:wheel_v0 prefix="right" parent="base_link">
    <origin xyz="0 -0.14199 0.074742"/>
    <axis xyz="0 1 0"/>
  </xacro:wheel_v0>
  <!-- Left Wheel -->
  <xacro:wheel_v0 prefix="left" parent="base_link">
    <origin xyz="0 0.14199 0.074742"  rpy="0 0 ${M_PI}" />
    <axis xyz="0 -1 0"/>
  </xacro:wheel_v0>
```

`vwheel.urdf.xacro`

```xml
  <xacro:macro name="wheel_v0" params="prefix parent *joint_origin *joint_axis">
    <joint name="${prefix}_wheel_joint" type="continuous">
      <xacro:insert_block name="joint_origin"/>
      <parent link="${parent}"/>
      <child link="${prefix}_wheel_link"/>
      <xacro:insert_block name="joint_axis"/>
    </joint>

    <link name="${prefix}_wheel_link">
      <visual>
        <geometry>
          <mesh filename="package://megarover_samples/meshes/dae/vmega_wheel.dae"/>
        </geometry>
      </visual>
      <collision>
        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 0"/>
        <geometry>
          <cylinder radius="${wheel_radius}" length="${wheel_length}"/>
        </geometry>
      </collision>
      <inertial>
        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 0"/>
        <xacro:cylinder_inertial mass="${wheel_mass}"
          radius="${wheel_radius}" length="${wheel_length}"/>
      </inertial>
    </link>
  </xacro:macro>
```