### PR TITLE
トピックのリレー処理追加（Gazebo）

### DIFF
--- a/launch/vmegarover_control.launch
+++ b/launch/vmegarover_control.launch
@@ -19,4 +19,8 @@ vmegarover.urdf.xacroなどから呼び出されます。
                 type="robot_state_publisher"
                 respawn="false" output="screen" ns="/vmegarover" />
 
+  <!-- relay topic for Gazebo -->
+  <node pkg="topic_tools" type="relay" name="cmd_vel_relay" args="/cmd_vel /vmegarover/diff_drive_controller/cmd_vel" />
+  <node pkg="topic_tools" type="relay" name="odom_relay" args="/vmegarover/diff_drive_controller/odom /odom" />
+
 </launch>

--- a/launch/vmegarover_move_base_dwa.launch
+++ b/launch/vmegarover_move_base_dwa.launch
@@ -61,8 +61,6 @@ Navigationサンプルのlaunch（シミュレータ用）
     <rosparam file="$(find megarover_samples)/configuration_files/megarover_global_costmap_params.yaml" command="load" />
     <rosparam file="$(find megarover_samples)/configuration_files/vmegarover_dwa_local_planner_params.yaml" command="load" />
     <rosparam file="$(find megarover_samples)/configuration_files/megarover_move_base_params.yaml" command="load" />
-    <remap from="cmd_vel" to="/vmegarover/diff_drive_controller/cmd_vel" />
-    <!-- remap from="odom" to="/vmegarover/diff_drive_controller/odom" / -->
   </node>
 
   <!-- Rviz -->


### PR DESCRIPTION
## 現象

ROS Melodic環境で以下のコマンドを実行していました。

```shell
roslaunch megarover_samples vmegarover_with_sample_world.launch
roslaunch megarover_samples vmegarover_move_base_dwa.launch map_file:=<mapfile>
```

RVizで現在地から障害物が無い直進で進める地点にゴールを出してcmd_velの値を見たところ、DWAのパラメータで設定している値から考えて非常に遅い速度で走行していたため確認していたところ、Gazebo環境時固有の問題があることがわかりました。

<https://github.com/vstoneofficial/megarover_samples/blob/a96803f5a6deca85b419c0b9633faab6f7079eec/launch/vmegarover_move_base_dwa.launch#L64-L65>を読むと、`/vmegarover/diff_drive_controller/odom`から`odom`へのremapがコメントアウトされています。そのため、Gazebo環境で動かした場合はodomトピックがないことになります。

一方で<http://wiki.ros.org/dwa_local_planner>ではodomトピックが必要であるため、正しく動いていないように見受けられます。gmappingやamclはodomトピックではなく、odomフレームを見ているため、たまたま動いているようです。

## 修正内容

Gazeboと実機でトピック名を合わせるためにlaunch/vmegarover_control.launchでリレーさせることで対応しました。